### PR TITLE
Battery Fully Charged Notification Re-Enable

### DIFF
--- a/core/res/res/values/cm_strings.xml
+++ b/core/res/res/values/cm_strings.xml
@@ -144,6 +144,10 @@
     <!-- Protected Apps Notification -->
     <string name="notify_package_component_protected_title">Activity launch blocked</string>
     <string name="notify_package_component_protected_text"><xliff:g id="app_name">%1$s</xliff:g> is protected from being launched. Tap to authenticate and launch the application.</string>
+     
+    <!-- Battery fully charged notification -->
+    <string name="notify_battery_fully_charged_title">Battery fully charged</string>
+    <string name="notify_battery_fully_charged_text">Disconnect your device from the charger to improve battery longevity.</string>
 
     <!-- Notify user that they are in Lock-to-app (for devices without navbar) -->
     <string name="lock_to_app_toast_no_navbar">To unpin this screen, touch and hold the Back button.</string>

--- a/core/res/res/values/cm_symbols.xml
+++ b/core/res/res/values/cm_symbols.xml
@@ -105,6 +105,11 @@
     <java-symbol type="string" name="tethered_notification_no_device_message" />
     <java-symbol type="string" name="tethered_notification_one_device_message" />
     <java-symbol type="string" name="tethered_notification_multi_device_message" />
+     
+    <!-- Show battery fully charged notification -->
+    <java-symbol type="bool" name="config_showBatteryFullyChargedNotification" />
+    <java-symbol type="string" name="notify_battery_fully_charged_title" />
+    <java-symbol type="string" name="notify_battery_fully_charged_text" />
 
     <!-- Whether notify fingerprint client of successful cancelled authentication -->
     <java-symbol type="bool" name="config_notifyClientOnFingerprintCancelSuccess" />

--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -2951,4 +2951,7 @@
 
     <!-- Whether notify fingerprint client of successful cancelled authentication -->
     <bool name="config_notifyClientOnFingerprintCancelSuccess">false</bool>
+     
+    <!-- Show battery fully charged notification -->
+    <bool name="config_showBatteryFullyChargedNotification">false</bool>
 </resources>

--- a/services/core/java/com/android/server/BatteryService.java
+++ b/services/core/java/com/android/server/BatteryService.java
@@ -28,7 +28,9 @@ import com.android.server.lights.Light;
 import com.android.server.lights.LightsManager;
 
 import android.app.ActivityManagerNative;
+import android.app.Notification;
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.ContentResolver;
 import android.content.Context;
@@ -172,6 +174,9 @@ public final class BatteryService extends SystemService {
     private boolean mMultiColorLed;
 
     private boolean mSentLowBatteryBroadcast = false;
+    
+    private boolean mShowBatteryFullyChargedNotification;
+    private boolean mIsShowingBatteryFullyChargedNotification;
 
     private final int mVbattSamplingIntervalMsec = 30000; /* sampling frequency - 30 seconds */
     private final int mWeakChgCutoffVoltageMv;
@@ -222,6 +227,9 @@ public final class BatteryService extends SystemService {
                 com.android.internal.R.integer.config_lowBatteryCloseWarningBump);
         mShutdownBatteryTemperature = mContext.getResources().getInteger(
                 com.android.internal.R.integer.config_shutdownBatteryTemperature);
+        
+        mShowBatteryFullyChargedNotification = mContext.getResources().getBoolean(
+                com.android.internal.R.bool.config_showBatteryFullyChargedNotification);
 
         // watch for invalid charger messages if the invalid_charger switch exists
         if (new File("/sys/devices/virtual/switch/invalid_charger/state").exists()) {
@@ -624,6 +632,12 @@ public final class BatteryService extends SystemService {
 
             // Update the battery LED
             mLed.updateLightsLocked();
+            
+            if (shouldShowBatteryFullyChargedNotificationLocked()) {
+                showBatteryFullyChargedNotificationLocked();
+            } else if (shouldClearBatteryFullyChargedNotificationLocked()) {
+                clearBatteryFullyChargedNotificationLocked();
+            }
 
             // This needs to be done after sendIntent() so that we get the lastest battery stats.
             if (logOutlier && dischargeDuration != 0) {
@@ -931,6 +945,56 @@ public final class BatteryService extends SystemService {
 
     private synchronized void updateLedPulse() {
         mLed.updateLightsLocked();
+        }
+
+    private boolean shouldShowBatteryFullyChargedNotificationLocked() {
+        return mShowBatteryFullyChargedNotification && mPlugType != 0
+                && mBatteryProps.batteryLevel == BATTERY_SCALE
+                && !mIsShowingBatteryFullyChargedNotification;
+    }
+
+    private void showBatteryFullyChargedNotificationLocked() {
+        NotificationManager nm = mContext.getSystemService(NotificationManager.class);
+        Intent intent = new Intent(Intent.ACTION_POWER_USAGE_SUMMARY);
+        PendingIntent pi = PendingIntent.getActivityAsUser(mContext, 0,
+                intent, 0, null, UserHandle.CURRENT);
+
+        CharSequence title = mContext.getText(
+                com.android.internal.R.string.notify_battery_fully_charged_title);
+        CharSequence message = mContext.getText(
+                com.android.internal.R.string.notify_battery_fully_charged_text);
+
+        Notification notification = new Notification.Builder(mContext)
+                .setSmallIcon(com.android.internal.R.drawable.stat_sys_battery_charge)
+                .setWhen(0)
+                .setOngoing(false)
+                .setAutoCancel(true)
+                .setTicker(title)
+                .setDefaults(0)  // please be quiet
+                .setPriority(Notification.PRIORITY_DEFAULT)
+                .setColor(mContext.getColor(
+                        com.android.internal.R.color.system_notification_accent_color))
+                .setContentTitle(title)
+                .setContentText(message)
+                .setStyle(new Notification.BigTextStyle().bigText(message))
+                .setContentIntent(pi)
+                .setVisibility(Notification.VISIBILITY_PUBLIC)
+                .build();
+
+        nm.notifyAsUser(null, com.android.internal.R.string.notify_battery_fully_charged_title,
+                notification, UserHandle.ALL);
+        mIsShowingBatteryFullyChargedNotification = true;
+    }
+
+    private boolean shouldClearBatteryFullyChargedNotificationLocked() {
+        return mIsShowingBatteryFullyChargedNotification &&
+                (mPlugType == 0 || mBatteryProps.batteryLevel < BATTERY_SCALE);
+    }
+
+    private void clearBatteryFullyChargedNotificationLocked() {
+        NotificationManager nm = mContext.getSystemService(NotificationManager.class);
+        nm.cancel(com.android.internal.R.string.notify_battery_fully_charged_title);
+        mIsShowingBatteryFullyChargedNotification = false;
     }
 
     private final class Led {


### PR DESCRIPTION
The following references are from the Cyanogen Mod, and were deprecated from Lineage OS. 
This is the code after successful attempt of porting it to Nougat.